### PR TITLE
Update check_encoding.py

### DIFF
--- a/.github/check_encoding.py
+++ b/.github/check_encoding.py
@@ -19,59 +19,30 @@ R_SCRIPT_FOLDERS = [
     os.path.normpath("clpss-db/DB/sql/*")
 ]
 
-# def is_windows1252_encoded(file_path):
-#     with open(file_path, 'rb') as f:
-#         raw = f.read()
-
-#     result = chardet.detect(raw)
-#     encoding = (result['encoding'] or '').lower()
-#     confidence = result.get('confidence', 0)
-
-#     print(f"{file_path}: Detected '{encoding}' (confidence: {confidence:.2f})")
-#     return encoding == 'windows-1252' and confidence >= 0.7
-
-# def main(files):
-#     failed = False
-#     for file_path in files:
-#         if not os.path.isfile(file_path):
-#             continue
-#         if not is_windows1252_encoded(file_path):
-#             print(f"File '{file_path}' is NOT Windows-1252 encoded!")
-#             failed = True
-#     if failed:
-#         sys.exit(1)
-#     print("All files are Windows-1252 encoded.")
-
-
-# def is_windows1252_encoded(file_path: str) -> bool:
-#     try:
-#         with open(file_path, 'rb') as f:
-#             raw = f.read()
-#         result = chardet.detect(raw)
-#         encoding = (result['encoding'] or '').lower()
-#         confidence = result.get('confidence', 0)
-#         print(f"{file_path}: Detected encoding '{encoding}' (confidence: {confidence:.2f})")
-#         return encoding == 'windows-1252' and confidence >= 0.80
-#     except Exception as e:
-#         print(f" Error reading or detecting encoding for {file_path}: {e}")
-#         return False
-
-def is_windows1252_encoded(file_path):
-    with open(file_path, 'rb') as file:
-        raw_data = file.read()
-        result = chardet.detect(raw_data)
-        encoding = result['encoding']
-        confidence = result['confidence']
-        print(f"{file_path}: detected encoding={encoding}, confidence={confidence}")
-        return encoding == 'Windows-1252'
+def is_windows1252_encoded(file_path, min_confidence=0.8):
+    try:
+        with open(file_path, 'rb') as f:
+            raw = f.read()
+        result = chardet.detect(raw)
+        encoding = (result['encoding'] or '').lower()
+        confidence = result.get('confidence', 0)
+        print(f"{file_path}: Detected encoding '{encoding}' (confidence: {confidence:.2f})")
+        return encoding == 'windows-1252' and confidence >= min_confidence
+    except Exception as e:
+        print(f"Error reading or detecting encoding for {file_path}: {e}")
+        return False
 
 def main(files):
+    failed = False
     for file_path in files:
         if not os.path.isfile(file_path):
             continue
         if not is_windows1252_encoded(file_path):
-            print(f"Issues found in file: {file_path}")
-            print("  - Invalid encoding (not Windows-1252)")   
+            print(f"File '{file_path}' is NOT Windows-1252 encoded!")
+            failed = True
+    if failed:
+        sys.exit(1)
+    print("All files are Windows-1252 encoded.")
 
 def is_valid_filename(filename):
     errors = []


### PR DESCRIPTION
## Summary by Sourcery

Standardize the Windows-1252 encoding check by parameterizing confidence, adding error handling, updating output messages, and cleaning up obsolete code.

Enhancements:
- Parameterize the minimum confidence threshold (default 0.8) in is_windows1252_encoded.
- Add exception handling in encoding detection to catch file read or detection errors.
- Standardize encoding detection output formatting and enforce lowercase comparison.
- Update main to track failures, print clear failure/success messages, and exit with a non-zero code on failures.
- Remove outdated commented code blocks related to previous detection implementations.